### PR TITLE
feat: integrate OpenZeppelin Contracts MCP and Slither MCP into skills

### DIFF
--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -6,6 +6,7 @@
 Before writing or modifying any Solidity contract (.sol files), you MUST invoke:
 - /solidity-coding
 - /solidity-security
+- When creating NEW contracts from scratch, prefer using OpenZeppelinContracts MCP tools (solidity-erc20, solidity-erc721, etc.) to generate the base contract, then customize with /solidity-coding rules
 
 Before writing or modifying test files (*.t.sol), you MUST invoke:
 - /solidity-testing
@@ -17,8 +18,10 @@ Before deploying contracts or writing deployment scripts (*.s.sol), you MUST inv
 Before debugging failed on-chain transactions, you MUST invoke:
 - /solidity-debug
 
-Before conducting security audits or code reviews, you MUST invoke:
-- /solidity-audit
+Before conducting security audits or code reviews, you MUST:
+- Run slither MCP analysis on the project first (if available) to get automated findings
+- Then invoke /solidity-audit for manual checklist review
+- Cross-reference both results for comprehensive coverage
 
 Before creating git commits or PRs, you MUST invoke:
 - /git-workflow
@@ -77,7 +80,12 @@ After every `/clear`, you MUST re-invoke:
 
 - **fetch**: Lightweight web fetching, suitable for API docs and static pages
 - **playwright**: Dynamic pages, JS-rendered content, screenshots
+- **OpenZeppelinContracts**: Generate secure smart contracts using OpenZeppelin standards (ERC20/721/1155/Governor/Account/Custom). Output is validated against OZ Contracts Wizard rules — imports, modifiers, security checks are guaranteed correct.
+- **slither**: Static analysis of Solidity projects via Slither engine (90+ detectors). Returns vulnerability findings with exact line numbers, impact levels, and confidence ratings.
 - Prefer fetch first, use playwright only when fetch is insufficient
+- Prefer OpenZeppelinContracts MCP for new contract scaffolding, then customize the output
+- Prefer slither MCP for automated scanning before manual /solidity-audit review
+- If MCP tools are not configured, all skills still work independently — graceful degradation
 
 ## Language
 

--- a/skills/solidity-audit/SKILL.md
+++ b/skills/solidity-audit/SKILL.md
@@ -210,6 +210,46 @@ Old contracts with known bugs remain callable on-chain forever.
 
 **Case**: [Truebit (Jan 2026, $26.4M)](https://www.coindesk.com/markets/2026/01/09/truebit-token-tru-crashes-99-9-after-usd26-6m-exploit-drains-8-535-eth) — Solidity 0.6.10 contract lacked overflow protection, attacker minted tokens at near-zero cost.
 
+## Automated Analysis with Slither MCP (if available)
+
+When `slither` MCP is configured, run automated analysis BEFORE the manual checklist below:
+
+### Recommended Audit Flow
+
+```
+Step 1: slither MCP automated scan
+        → get_detector_results(path, impact="High")
+        → get_detector_results(path, impact="Medium")
+Step 2: Review Slither findings — triage true positives vs false positives
+Step 3: Manual checklist below — catch what Slither misses (business logic, economic attacks)
+Step 4: Cross-reference — Slither + manual findings combined into final report
+```
+
+### Slither MCP Tools
+
+| Tool | Usage | Complements |
+|---|---|---|
+| `get_contract_metadata` | Extract functions, inheritance, flags | Manual access control review |
+| `get_function_source` | Get exact source code with line numbers | Faster than grep for locating code |
+| `find_implementations` | Find all implementations of a function signature | Cross-contract reentrancy analysis |
+| `get_detector_results` | Run 90+ security detectors, filter by impact/confidence | Automated version of manual checklist |
+| `get_detector_metadata` | List available detectors with descriptions | Understanding what's being checked |
+
+### What Slither Catches vs What It Misses
+
+| Slither Catches Well | Manual Review Still Needed |
+|---|---|
+| Reentrancy patterns | Business logic flaws |
+| Unprotected functions | Economic attack vectors (flash loan combos) |
+| Unused state variables | Cross-protocol composability risks |
+| Shadowing issues | Oracle manipulation scenarios |
+| Incorrect ERC20 interface | Trust boundary architecture issues |
+| Dead code | MEV/front-running specific to business logic |
+
+**Key Principle**: Slither provides ground truth via static analysis — reduces false negatives on known vulnerability patterns. But it cannot reason about protocol-level economic attacks — that's where the manual checklist below is essential.
+
+**Graceful degradation**: If slither MCP is not configured, skip this section and proceed directly to the manual checklist. All checklist items remain valid and self-contained.
+
 ## Audit Execution Checklist
 
 When conducting a security audit, check each item:

--- a/skills/solidity-coding/SKILL.md
+++ b/skills/solidity-coding/SKILL.md
@@ -169,6 +169,29 @@ Will contract need upgrades?
 - **Do NOT** use `require(token.transfer(...))` — use `token.safeTransfer(...)` via `SafeERC20`
 - **Do NOT** use `tx.origin` for auth — use `msg.sender` with `Ownable` / `AccessControl`
 
+## MCP-Assisted Contract Generation (if available)
+
+When `OpenZeppelinContracts` MCP is configured, prefer using it to generate base contracts instead of writing from scratch:
+
+| Contract Type | MCP Tool | When to Use |
+|---|---|---|
+| Fungible token | `solidity-erc20` | Any new ERC20 token contract |
+| NFT | `solidity-erc721` | Any new NFT contract |
+| Multi-token | `solidity-erc1155` | Game items, batch operations |
+| Stablecoin | `solidity-stablecoin` | Stablecoin with ERC20 compliance |
+| Real-world assets | `solidity-rwa` | Asset tokenization |
+| Smart account | `solidity-account` | ERC-4337 account abstraction |
+| Governance | `solidity-governor` | DAO voting and proposals |
+| Custom | `solidity-custom` | Non-standard contracts with OZ patterns |
+
+**Workflow**: MCP generates base → apply this skill's naming/structure rules → customize business logic → apply /solidity-security rules
+
+**Why MCP over manual**: MCP output is validated against the same rule-set as OZ Contracts Wizard — imports, modifiers, security checks are guaranteed correct. Manual coding risks missing imports or using wrong OZ versions.
+
+**When NOT to use MCP**: Heavily custom contracts with non-standard patterns, contracts that don't fit any OZ template, or when you need fine-grained control from line 1.
+
+**Graceful degradation**: If MCP is not configured, fall back to the Library Selection Standards above and write contracts manually following all rules in this skill.
+
 ## Foundry Quick Reference
 
 | Operation | Command |

--- a/skills/solidity-security/SKILL.md
+++ b/skills/solidity-security/SKILL.md
@@ -113,6 +113,21 @@ forge coverage
 # Dry-run deployment to verify no runtime errors
 forge script script/Deploy.s.sol --fork-url $RPC_URL -vvvv
 
-# Static analysis (if slither installed)
+# Static analysis (if slither installed locally)
 slither src/
 ```
+
+### Slither MCP Integration (if available)
+
+When `slither` MCP is configured, prefer it over the CLI for structured analysis:
+
+| Approach | When to Use |
+|---|---|
+| `slither src/` (CLI) | Quick local scan, raw terminal output |
+| slither MCP `get_detector_results` | Structured results with impact/confidence filtering, AI can parse and reason about findings |
+| slither MCP `get_contract_metadata` | Understanding contract structure before reviewing code |
+| slither MCP `get_function_source` | Locating exact function implementations faster than grep |
+
+**Recommended**: Use slither MCP when working with AI agents (results are structured and actionable). Use CLI for quick local checks during development.
+
+**Graceful degradation**: If neither slither MCP nor slither CLI is available, rely on the Pre-Audit Checklist above and `forge test --fuzz-runs 10000` for coverage.


### PR DESCRIPTION
Add MCP best practices to guide AI agents on when and how to use OpenZeppelinContracts MCP for contract generation and Slither MCP for automated security analysis. All additions follow graceful degradation — skills remain fully functional without MCP configured.

- CLAUDE.md.template: add MCP tool descriptions and auto-invoke rules
- solidity-coding: add MCP-Assisted Contract Generation section
- solidity-audit: add Automated Analysis with Slither MCP section
- solidity-security: extend verification commands with MCP integration